### PR TITLE
Fixing AttributeError

### DIFF
--- a/micmon/audio/file.py
+++ b/micmon/audio/file.py
@@ -15,8 +15,8 @@ class AudioFile(AudioSource):
                  *args, **kwargs):
         super().__init__(*args, **kwargs)
         if isinstance(audio_file, AudioDirectory):
-            audio_file = audio_file.audio_file
             labels_file = audio_file.labels_file
+            audio_file = audio_file.audio_file
 
         self.audio_file = os.path.abspath(os.path.expanduser(audio_file))
 


### PR DESCRIPTION
Calling `AudioFile(audio_dir)` where `audio_dir` is a `AudioDirectory` object was causing an `AttributeError`, since the `audio_file` variable was being replaced by a string, before the `labels_file` variable was read out from it.